### PR TITLE
Add a decorative horn to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Foghorn
+# Foghorn 📯
 
 Foghorn is a fully Kubernetes-native CI system, inspired by [prow](https://github.com/kubernetes/test-infra/tree/master/prow). It's powered by [Tekton Pipelines](https://github.com/tektoncd/pipeline), which provides a number of handy abstractions for defining CI pipelines in a k8s-native way. Foghorn provides webhook handling and some git-centric CommentOps features, and it supports multiple git providers.
 


### PR DESCRIPTION
Since there's no foghorn emoji, we're using a postal horn emoji.

This commit is also a intended as a pipe cleaner for the prow
configuration.